### PR TITLE
Optional Chromium support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  test:
+    name: 'Test on Node.js v${{ matrix.node }} / ${{ matrix.os }}'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        node: [10, 12, 14, 16]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install
+      - run: npm test

--- a/chrome-finder/darwin.js
+++ b/chrome-finder/darwin.js
@@ -1,5 +1,5 @@
 const { execSync } = require('child_process');
-const path = require('path');
+const path = require('path').posix;
 const { canAccess, newLineRegex, sort } = require('./util');
 
 function darwin() {

--- a/chrome-finder/darwin.js
+++ b/chrome-finder/darwin.js
@@ -2,11 +2,11 @@ const { execSync } = require('child_process');
 const path = require('path').posix;
 const { canAccess, newLineRegex, sort } = require('./util');
 
-function darwin() {
+function darwin(includeChromium = false) {
   const suffixes = [
     // '/Contents/MacOS/Google Chrome Canary', 
     '/Contents/MacOS/Google Chrome', 
-    // '/Contents/MacOS/Chromium'
+    ... includeChromium ? ['/Contents/MacOS/Chromium'] : []
   ];
 
   const LSREGISTER = '/System/Library/Frameworks/CoreServices.framework' +
@@ -34,13 +34,13 @@ function darwin() {
 
   // Retains one per line to maintain readability.
   const priorities = [
-    // { regex: new RegExp(`^${process.env.HOME}/Applications/.*Chromium.app`), weight: 49 },
+    { regex: new RegExp(`^${process.env.HOME}/Applications/.*Chromium.app`), weight: 49 },
     { regex: new RegExp(`^${process.env.HOME}/Applications/.*Chrome.app`), weight: 50 },
     // { regex: new RegExp(`^${process.env.HOME}/Applications/.*Chrome Canary.app`), weight: 51 },
-    // { regex: /^\/Applications\/.*Chromium.app/, weight: 99 },
+    { regex: /^\/Applications\/.*Chromium.app/, weight: 99 },
     { regex: /^\/Applications\/.*Chrome.app/, weight: 100 },
     // { regex: /^\/Applications\/.*Chrome Canary.app/, weight: 101 },
-    // { regex: /^\/Volumes\/.*Chromium.app/, weight: -3 },
+    { regex: /^\/Volumes\/.*Chromium.app/, weight: -3 },
     { regex: /^\/Volumes\/.*Chrome.app/, weight: -2 },
     // { regex: /^\/Volumes\/.*Chrome Canary.app/, weight: -1 }
   ];

--- a/chrome-finder/darwin.js
+++ b/chrome-finder/darwin.js
@@ -17,8 +17,10 @@ function darwin() {
 
   execSync(
     `${LSREGISTER} -dump` +
-    ' | grep -E -i \'(google chrome( canary)?|chromium).app$\'' +
-    ' | awk \'{$1=""; print $0}\'')
+    ' | grep -E -i \'(google chrome( canary)?' + (includeChromium ? '|chromium' : '') + ').app(\\s\\(0x[0-9a-f]+\\))?$\'' +
+    ' | awk \'sub(/\\(0x[0-9a-f]+\\)/, "")\'' +
+    ' | awk \'{$1=""; print $0}\'' +
+    ' | awk \'{ gsub(/^[ \\t]+|[ \\t]+$/, ""); print }\'')
     .toString()
     .split(newLineRegex)
     .forEach((inst) => {

--- a/chrome-finder/index.js
+++ b/chrome-finder/index.js
@@ -3,24 +3,28 @@ const ERROR_PLATFORM_NOT_SUPPORT = new Error('platform not support');
 const ERROR_NO_INSTALLATIONS_FOUND = new Error('no chrome installations found');
 
 /**
- * find a executable chrome for all support system
- * @returns {string} executable chrome full path
+ * Find a executable Chrome (or Chromium) for all supported systems.
+ *
+ * Supports macOS, Linux, and Windows.
+ *
+ * @param {boolean} includeChromium true if we should consider Chromium in our search, false otherwise.
+ * @returns {string} the first full path to an executable Chrome (or Chromium)
  * @throws
- * if no executable chrome find, ERROR_NO_INSTALLATIONS_FOUND will be throw
+ * if no executable Chrome (or Chromium) find, ERROR_NO_INSTALLATIONS_FOUND will be throw
  * if platform is not one if ['win32','darwin','linux'], ERROR_PLATFORM_NOT_SUPPORT will be throw
  */
-function findChrome() {
+function findChrome(includeChromium = false) {
   const { platform } = process;
   let installations = [];
   switch (platform) {
     case 'win32':
-      installations = require('./win32')();
+      installations = require('./win32')(includeChromium);
       break;
     case 'darwin':
-      installations = require('./darwin')();
+      installations = require('./darwin')(includeChromium);
       break;
     case 'linux':
-      installations = require('./linux')();
+      installations = require('./linux')(includeChromium);
       break;
     default:
       throw ERROR_PLATFORM_NOT_SUPPORT;

--- a/chrome-finder/linux.js
+++ b/chrome-finder/linux.js
@@ -4,9 +4,9 @@ const fs = require('fs');
 const { canAccess, sort, isExecutable, newLineRegex } = require('./util');
 
 
-function findChromeExecutablesForLinuxDesktop(folder) {
+function findChromeExecutablesForLinuxDesktop(folder, includeChromium = false) {
   const argumentsRegex = /(^[^ ]+).*/; // Take everything up to the first space
-  const chromeExecRegex = '^Exec=\/.*\/(google|chrome|chromium)-.*';
+  const chromeExecRegex = '^Exec=\/.*\/(google|chrome' + (includeChromium ? '|chromium' : '') + ')-.*';
 
   let installations = [];
   if (canAccess(folder)) {
@@ -27,77 +27,82 @@ function findChromeExecutablesForLinuxDesktop(folder) {
   return installations;
 }
 
+function findChromeExecutablesForLinux(validChromePaths, includeChromium = false) {
+  const executables = [
+    'google-chrome-stable',
+    'google-chrome',
+    ... includeChromium ? ['chromium', 'chromium-browser', 'chromium/chrome'] : []  // chromium/chrome is for toradex machines where "chromium" is a directory. seen on Angstrom v2016.12
+  ];
+
+  return executables.map(executable => {
+    const existingPaths = validChromePaths.map(possiblePath => {
+      try {
+        const chromePathToTest = possiblePath + '/' + executable;
+        if (fs.existsSync(chromePathToTest) && canAccess(chromePathToTest) && isExecutable(chromePathToTest)) {
+          return [ chromePathToTest ];
+        }
+      } catch (err) {
+        // not installed on this path or inaccessible
+      }
+      return [];
+    }).reduce((acc, val) => acc.concat(val), []); //.filter((foundChromePath) => foundChromePath);
+
+    // skip asking "which" command if the binary was found by searching the known paths.
+    if (existingPaths && existingPaths.length > 0) {
+      return existingPaths;
+    }
+
+    try {
+      const chromePath = execFileSync('which', [executable]).toString().split(newLineRegex)[0];
+      if (canAccess(chromePath)) {
+        return [ chromePath ];
+      }
+    } catch (err) {
+      // cmd which not installed.
+    }
+
+    return [];
+
+  }).reduce((acc, val) => acc.concat(val), []);
+}
 
 /**
  * Look for linux executables in 2 ways
  * 1. Look into the directories where .desktop are saved on gnome based distro's
- * 2. Look for google-chrome-stable & google-chrome executables by using the which command
+ * 2. Look for google-chrome-stable and google-chrome executables by using the which command
+ * If includeChromium is set, also look for chromium, chromium-browser, and chromium/chrome executables by using the which command
  */
-function linux() {
+function linux(includeChromium = false) {
   let installations = [];
 
-  // 2. Look into the directories where .desktop are saved on gnome based distro's
+  // 1. Look into the directories where .desktop are saved on gnome based distro's
   const desktopInstallationFolders = [
     path.join(require('os').homedir(), '.local/share/applications/'),
     '/usr/share/applications/',
   ];
   desktopInstallationFolders.forEach(folder => {
-    installations = installations.concat(findChromeExecutablesForLinuxDesktop(folder));
+    installations = installations.concat(findChromeExecutablesForLinuxDesktop(folder, includeChromium));
   });
 
-  // Look for google-chrome-stable & google-chrome executables by using the which command
-  const executables = [
-    'google-chrome-stable',
-    'google-chrome',
-    // 'chromium',
-    // 'chromium-browser',
-    // 'chromium/chrome',   // on toradex machines "chromium" is a directory. seen on Angstrom v2016.12
+  // 2. Look for google-chrome-stable and google-chrome (and optionally chromium, chromium-browser, and chromium-chrome) executables by using the which command
+  // see http://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/
+  const validChromePaths = [
+    '/usr/bin',
+    '/usr/local/bin',
+    '/usr/sbin',
+    '/usr/local/sbin',
+    '/opt/bin',
+    '/usr/bin/X11',
+    '/usr/X11R6/bin'
   ];
-  executables.forEach((executable) => {
-    // see http://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/
-    const validChromePaths = [
-      '/usr/bin',
-      '/usr/local/bin',
-      '/usr/sbin',
-      '/usr/local/sbin',
-      '/opt/bin',
-      '/usr/bin/X11',
-      '/usr/X11R6/bin'
-    ].map((possiblePath) => {
-      try {
-        const chromePathToTest = possiblePath + '/' + executable;
-        if (fs.existsSync(chromePathToTest) && canAccess(chromePathToTest) && isExecutable(chromePathToTest)) {
-          installations.push(chromePathToTest);
-          return chromePathToTest;
-        }
-      } catch (err) {
-        // not installed on this path or inaccessible
-      }
-      return undefined;
-    }).filter((foundChromePath) => foundChromePath);
-
-    // skip asking "which" command if the binary was found by searching the known paths.
-    if (validChromePaths && validChromePaths.length > 0) {
-      return;
-    }
-
-    try {
-      const chromePath =
-        execFileSync('which', [executable]).toString().split(newLineRegex)[0];
-      if (canAccess(chromePath)) {
-        installations.push(chromePath);
-      }
-    } catch (err) {
-      // cmd which not installed.
-    }
-  });
+  installations = installations.concat(findChromeExecutablesForLinux(validChromePaths, includeChromium));
 
   const priorities = [
-    // { regex: /chromium$/, weight: 52 },
+    { regex: /chromium$/, weight: 52 },
     { regex: /chrome-wrapper$/, weight: 51 },
     { regex: /google-chrome-stable$/, weight: 50 },
     { regex: /google-chrome$/, weight: 49 },
-    // { regex: /chromium-browser$/, weight: 48 },
+    { regex: /chromium-browser$/, weight: 48 },
     { regex: /chrome$/, weight: 47 },
   ];
 

--- a/chrome-finder/linux.js
+++ b/chrome-finder/linux.js
@@ -1,5 +1,5 @@
 const { execSync, execFileSync } = require('child_process');
-const path = require('path');
+const path = require('path').posix;
 const fs = require('fs');
 const { canAccess, sort, isExecutable, newLineRegex } = require('./util');
 

--- a/chrome-finder/win32.js
+++ b/chrome-finder/win32.js
@@ -1,24 +1,23 @@
 const path = require('path').win32;
 const { canAccess } = require('./util');
 
-function win32() {
+
+function win32(includeChromium = false) {
   const installations = [];
   const suffixes = [
     '\\Google\\Chrome SxS\\Application\\chrome.exe',
     '\\Google\\Chrome\\Application\\chrome.exe',
     '\\chrome-win32\\chrome.exe',
-    '\\Chromium\\Application\\chrome.exe',
+    ... includeChromium ? ['\\Chromium\\Application\\chrome.exe'] : [],
     // '\\Google\\Chrome Beta\\Application\\chrome.exe',
   ];
   const prefixes =
-    [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']];
+    [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']].filter(prefix => prefix);  // filter out undefined
 
   prefixes.forEach(prefix => suffixes.forEach(suffix => {
-    if (prefix) {
-      const chromePath = path.join(prefix, suffix);
-      if (canAccess(chromePath)) {
-        installations.push(chromePath);
-      }
+    const chromePath = path.join(prefix, suffix);
+    if (canAccess(chromePath)) {
+      installations.push(chromePath);
     }
   }));
   return installations;

--- a/chrome-finder/win32.js
+++ b/chrome-finder/win32.js
@@ -1,5 +1,6 @@
 const path = require('path').win32;
 const { canAccess } = require('./util');
+const procesEnv = process.env;
 
 
 function win32(includeChromium = false) {
@@ -11,8 +12,11 @@ function win32(includeChromium = false) {
     ... includeChromium ? ['\\Chromium\\Application\\chrome.exe'] : [],
     // '\\Google\\Chrome Beta\\Application\\chrome.exe',
   ];
-  const prefixes =
-    [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']].filter(prefix => prefix);  // filter out undefined
+  const prefixes = [
+    procesEnv.LOCALAPPDATA,
+    procesEnv.PROGRAMFILES,
+    procesEnv['PROGRAMFILES(X86)']
+  ].filter(prefix => prefix);  // filter out undefined
 
   prefixes.forEach(prefix => suffixes.forEach(suffix => {
     const chromePath = path.join(prefix, suffix);

--- a/chrome-finder/win32.js
+++ b/chrome-finder/win32.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('path').win32;
 const { canAccess } = require('./util');
 
 function win32() {

--- a/index.js
+++ b/index.js
@@ -50,17 +50,18 @@ async function getChromeVersionWin(includeChromium) {
 
 function getChromeVersionFromOsa(includeChromium) {
 
-    if (includeChromium) {
-        try {
-            const version = execSync('osascript -e \'tell application "Chromium" to get version\'').toString().trim();
-            return version;
-        } catch (err) {
-            // no-op
+    try {
+        const version = execSync('osascript -e \'tell application "Google Chrome" to get version\'').toString().trim();
+        return version;
+    } catch (err) {
+        if (!includeChromium) {
+            return null;
         }
+        // else fall-through to check for Chromium below
     }
 
     try {
-        const version = execSync('osascript -e \'tell application "Google Chrome" to get version\'').toString().trim();
+        const version = execSync('osascript -e \'tell application "Chromium" to get version\'').toString().trim();
         return version;
     } catch (err) {
         return null;

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ async function getChromeVersionFromCli(includeChromium) {
 }
 
 function extractChromeVersionNumer(chromeVersionString) {
-    return chromeVersionString.substr(14).trim();
+    return chromeVersionString.replace(/.+\s([0-9]+(\.[0-9]+)*)\s?.*/, '$1');
 }
 
 async function getChromeVersionWin(includeChromium) {

--- a/index.js
+++ b/index.js
@@ -18,9 +18,12 @@ async function getChromeVersionFromCli() {
 
     const res = await exec(chromePath.replace(/ /g, '\\ ') + ' --version');
 
-    const version = res.stdout.substr(14).trim();
+    const version = extractChromeVersionNumer(res.stdout);
     return version;
+}
 
+function extractChromeVersionNumer(chromeVersionString) {
+    return chromeVersionString.substr(14).trim();
 }
 
 async function getChromeVersionWin() {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Finds the version of Chrome that is installed on your machine",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint *.js --fix"
+    "lint": "eslint *.js --fix",
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -13,8 +14,13 @@
   "author": "Elad Katz",
   "license": "MIT",
   "homepage": "https://github.com/testimio/chrome-version",
-  "keywords": ["chrome", "version" ],
+  "keywords": [
+    "chrome",
+    "version"
+  ],
   "devDependencies": {
-    "eslint": "^6.4.0"
+    "eslint": "^6.4.0",
+    "mocha": "^8.4.0",
+    "rewire": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "version"
   ],
   "devDependencies": {
+    "chai": "^4.3.4",
     "eslint": "^6.4.0",
     "mocha": "^8.4.0",
     "rewire": "^6.0.0"

--- a/readme.MD
+++ b/readme.MD
@@ -16,4 +16,9 @@ npm install @testim/chrome-version
 })();
 ```
 
+## Testing
+```sh
+npm test
+```
+
 * If no version of chrome is installed on your machine `getChromeVersion` will return null.

--- a/readme.MD
+++ b/readme.MD
@@ -1,5 +1,7 @@
 # chrome-version
 
+[![Build Status](https://github.com/testimio/chrome-version/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/testimio/chrome-version/actions/workflows/ci.yml)
+
 Finds the version of Chrome (or Chromium) that is installed on your machine.
 
 ## Installation

--- a/readme.MD
+++ b/readme.MD
@@ -1,6 +1,6 @@
 # chrome-version
 
-Finds the version of Chrome that is installed on your machine.
+Finds the version of Chrome (or Chromium) that is installed on your machine.
 
 ## Installation
 ```sh
@@ -11,7 +11,8 @@ npm install @testim/chrome-version
 ```js
 (async () => {
     const { getChromeVersion } = require('chrome-version');
-    const version = await getChromeVersion();
+    const includeChromium = false;  // NOTE: set to true to also search for Chromium
+    const version = await getChromeVersion(includeChromium);
     console.log(version);
 })();
 ```

--- a/test/test.js
+++ b/test/test.js
@@ -1,32 +1,342 @@
-const assert = require('assert');
+const chai = require('chai');
+const expect = chai.expect;
+const Buffer = require('buffer').Buffer;
+
+// rewrite to get access for testing
 const rewire = require("rewire");
 const chromeVersionModule = rewire("../index.js");
 const extractChromeVersionNumer = chromeVersionModule.__get__('extractChromeVersionNumer');
+const getChromeVersionFromOsa = chromeVersionModule.__get__('getChromeVersionFromOsa');
+const chromeFinderLinuxModule = rewire("../chrome-finder/linux.js");
+const findChromeExecutablesForLinuxDesktop = chromeFinderLinuxModule.__get__('findChromeExecutablesForLinuxDesktop');
+const findChromeExecutablesForLinux = chromeFinderLinuxModule.__get__('findChromeExecutablesForLinux');
+const chromeFinderDarwinModule = rewire("../chrome-finder/darwin.js");
+const findChromeForDarwin = chromeFinderDarwinModule.__get__('darwin');
+const chromeFinderWin32Module = rewire("../chrome-finder/win32.js");
+const findChromeForWin32 = chromeFinderWin32Module.__get__('win32');
 
-describe('extractChromeVersionNumer', function() {
+describe('Chrome Finder', function() {
 
-  describe('Google Chrome 95.0.4638', function() {
+  describe('extractChromeVersionNumer from Google Chrome 95.0.4638', function() {
     it('should return "95.0.4638"', function() {
       const versionString = 'Google Chrome 95.0.4638';
       const versionNumber = extractChromeVersionNumer(versionString);
-      assert.equal(versionNumber, '95.0.4638');
+      expect(versionNumber).to.equal('95.0.4638');
     });
   });
 
-  describe('Google Chrome 96.0.4664.110', function() {
+  describe('extractChromeVersionNumer from Google Chrome 96.0.4664.110', function() {
     it('should return "96.0.4664.110"', function() {
       const versionString = 'Google Chrome 96.0.4664.110';
       const versionNumber = extractChromeVersionNumer(versionString);
-      assert.equal(versionNumber, '96.0.4664.110');
+      expect(versionNumber).to.equal('96.0.4664.110');
     });
   });
 
-  describe('Google Chrome 97.0.4692.71', function() {
+  describe('extractChromeVersionNumer from Google Chrome 97.0.4692.71', function() {
     it('should return "97.0.4692.71"', function() {
       const versionString = 'Google Chrome 97.0.4692.71';
       const versionNumber = extractChromeVersionNumer(versionString);
-      assert.equal(versionNumber, '97.0.4692.71');
+      expect(versionNumber).to.equal('97.0.4692.71');
     });
   });
 
+  describe('getChromeVersionFromOsa when includeChromium=false', function() {
+    it('should only find Chrome', function() {
+      const includeChromium = false;
+
+      const mockVersion = '97.0.4692.71';
+
+      var execSyncCommand;
+      chromeVersionModule.__set__('execSync', function(command) {
+          execSyncCommand = command;
+          return Buffer.from(mockVersion);
+      });
+
+      const version = getChromeVersionFromOsa(includeChromium);
+
+      expect(execSyncCommand).to.include('Google Chrome');
+      expect(execSyncCommand).to.not.include('Chromium');
+
+      expect(version).to.equal(mockVersion);
+    });
+  });
+
+  describe('getChromeVersionFromOsa when includeChromium=true', function() {
+    it('should only find Chromium', function() {
+      const includeChromium = true;
+
+      const mockVersion = '98.0.4753.0';
+
+      var execSyncCommand;
+      chromeVersionModule.__set__('execSync', function(command) {
+          execSyncCommand = command;
+          return Buffer.from(mockVersion);
+      });
+
+      const version = getChromeVersionFromOsa(includeChromium);
+
+      expect(execSyncCommand).to.not.include('Google Chrome');
+      expect(execSyncCommand).to.include('Chromium');
+
+      expect(version).to.equal(mockVersion);
+    });
+  });
+});
+
+describe('Chrome Finder Linux Module', function() {
+
+  describe('Linux Desktop when includeChromium=false', function() {
+    it('should only find Chrome', function() {
+
+      const includeChromium = false;
+
+      const mockChromePaths = [
+        '/opt/google/chrome/google-chrome',
+        '/home/user/Downloads/chrome-linux/chrome-wrapper'
+      ];
+
+      chromeFinderLinuxModule.__set__('canAccess', function(file) {
+        return true;
+      });
+
+      var execSyncCommand;
+      chromeFinderLinuxModule.__set__('execSync', function(command) {
+          execSyncCommand = command;
+          return Buffer.from(mockChromePaths.join('\n'));
+      });
+
+      const mockDesktopFolder = "mock-desktop-folder";
+      const executables = findChromeExecutablesForLinuxDesktop(mockDesktopFolder, includeChromium);
+
+      expect(execSyncCommand).to.include(mockDesktopFolder);
+      expect(execSyncCommand).to.not.include('|chromium');
+
+      expect(executables).to.have.lengthOf(2);
+      expect(executables).to.deep.equal(mockChromePaths);
+    });
+  });
+
+  describe('Linux Desktop when includeChromium=true', function() {
+    it('should find Chrome and Chromium', function() {
+
+      const includeChromium = true;
+
+      const mockChromePaths = [
+        '/opt/google/chrome/google-chrome',
+        '/home/user/Downloads/chrome-linux/chrome-wrapper',
+        '/usr/local/bin/chromium-browser'
+      ];
+
+      chromeFinderLinuxModule.__set__('canAccess', function(file) {
+        return true;
+      });
+
+      var execSyncCommand;
+      chromeFinderLinuxModule.__set__('execSync', function(command) {
+          execSyncCommand = command;
+          return Buffer.from(mockChromePaths.join('\n'));
+      });
+
+      const mockDesktopFolder = "mock-desktop-folder";
+      const executables = findChromeExecutablesForLinuxDesktop(mockDesktopFolder, includeChromium);
+
+      expect(execSyncCommand).to.include(mockDesktopFolder);
+      expect(execSyncCommand).to.include('|chromium');
+
+      expect(executables).to.have.lengthOf(3);
+      expect(executables).to.deep.equal(mockChromePaths);
+    });
+  });
+
+  describe('Linux when includeChromium=false', function() {
+    it('should only find Chrome', function() {
+
+      const includeChromium = false;
+
+      const mockPaths = [
+        '/mock-path'
+      ];
+
+      chromeFinderLinuxModule.__set__('fs', {
+        existsSync: function(file) {
+          return true;
+        }
+      });
+      chromeFinderLinuxModule.__set__('canAccess', function(file) {
+        return true;
+      });
+      chromeFinderLinuxModule.__set__('isExecutable', function(file) {
+        return true;
+      });
+
+      const executables = findChromeExecutablesForLinux(mockPaths, includeChromium);
+      expect(executables).to.have.lengthOf(2);
+
+      const expectedExecutables = mockPaths.map(mockPath => ['google-chrome-stable', 'google-chrome'].map(executable => mockPath + '/' + executable)).reduce((acc, val) => acc.concat(val), []);
+      expect(executables).to.deep.equal(expectedExecutables);
+    });
+  });
+
+  describe('Linux when includeChromium=true', function() {
+    it('should find Chrome and Chromium', function() {
+
+      const includeChromium = true;
+
+      const mockPaths = [
+        '/mock-path'
+      ];
+
+      chromeFinderLinuxModule.__set__('fs', {
+        existsSync: function(file) {
+          return true;
+        }
+      });
+      chromeFinderLinuxModule.__set__('canAccess', function(file) {
+        return true;
+      });
+      chromeFinderLinuxModule.__set__('isExecutable', function(file) {
+        return true;
+      });
+
+      const executables = findChromeExecutablesForLinux(mockPaths, includeChromium);
+      expect(executables).to.have.lengthOf(5);
+
+      const expectedExecutables = mockPaths.map(mockPath => ['google-chrome-stable', 'google-chrome', 'chromium', 'chromium-browser', 'chromium/chrome'].map(executable => mockPath + '/' + executable)).reduce((acc, val) => acc.concat(val), []);
+      expect(executables).to.deep.equal(expectedExecutables);
+    });
+  });
+});
+
+describe('Chrome Finder Darwin Module', function() {
+
+  describe('Darwin when includeChromium=false', function() {
+    it('should only find Chrome', function() {
+
+      const includeChromium = false;
+
+      const mockChromePaths = [
+        '/Applications/Google Chrome.app'
+      ];
+
+      chromeFinderDarwinModule.__set__('canAccess', function(file) {
+        return true;
+      });
+
+      var execSyncCommand;
+      chromeFinderDarwinModule.__set__('execSync', function(command) {
+          execSyncCommand = command;
+          return Buffer.from(mockChromePaths.join('\n'));
+      });
+
+      const executables = findChromeForDarwin(includeChromium);
+      expect(execSyncCommand).to.not.include('|chromium');
+
+      expect(executables).to.have.lengthOf(1);
+      expect(executables).to.deep.equal(mockChromePaths.map(mockChromePath => mockChromePath + '/Contents/MacOS/Google Chrome'));
+    });
+  });
+
+  describe('Darwin when includeChromium=true', function() {
+    it('should only find Chrome', function() {
+
+      const includeChromium = true;
+
+      const mockChromePaths = [
+        '/Applications/Google Chrome.app',
+        '/Applications/Chromium.app'
+      ];
+
+      const expectedExecutables = [
+        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        '/Applications/Chromium.app/Contents/MacOS/Chromium'
+      ];
+
+      chromeFinderDarwinModule.__set__('canAccess', function(file) {
+        return expectedExecutables.includes(file);
+      });
+
+      var execSyncCommand;
+      chromeFinderDarwinModule.__set__('execSync', function(command) {
+          execSyncCommand = command;
+          return Buffer.from(mockChromePaths.join('\n'));
+      });
+
+      const executables = findChromeForDarwin(includeChromium);
+      expect(execSyncCommand).to.include('|chromium');
+
+      expect(executables).to.have.lengthOf(2);
+      expect(executables).to.deep.equal(expectedExecutables);
+    });
+  });
+});
+
+describe('Chrome Finder Win32 Module', function() {
+
+  describe('Win32 when includeChromium=false', function() {
+    it('should only find Chrome', function() {
+
+      const includeChromium = false;
+
+      chromeFinderWin32Module.__set__('canAccess', function(file) {
+        return true;
+      });
+
+      chromeFinderWin32Module.__set__('procesEnv', {
+        LOCALAPPDATA: 'mock-local-app-data',
+        PROGRAMFILES: 'mock-program-files',
+        'PROGRAMFILES(X86)': 'mock-program-files-x86'
+      });
+
+      const executables = findChromeForWin32(includeChromium);
+
+      expect(executables).to.have.lengthOf(9);
+      expect(executables).to.deep.equal([
+        'mock-local-app-data\\Google\\Chrome SxS\\Application\\chrome.exe',
+        'mock-local-app-data\\Google\\Chrome\\Application\\chrome.exe',
+        'mock-local-app-data\\chrome-win32\\chrome.exe',
+        'mock-program-files\\Google\\Chrome SxS\\Application\\chrome.exe',
+        'mock-program-files\\Google\\Chrome\\Application\\chrome.exe',
+        'mock-program-files\\chrome-win32\\chrome.exe',
+        'mock-program-files-x86\\Google\\Chrome SxS\\Application\\chrome.exe',
+        'mock-program-files-x86\\Google\\Chrome\\Application\\chrome.exe',
+        'mock-program-files-x86\\chrome-win32\\chrome.exe'
+      ]);
+    });
+  });
+
+  describe('Win32 when includeChromium=true', function() {
+    it('should only find Chrome', function() {
+
+      const includeChromium = true;
+
+      chromeFinderWin32Module.__set__('canAccess', function(file) {
+        return true;
+      });
+
+      chromeFinderWin32Module.__set__('procesEnv', {
+        LOCALAPPDATA: 'mock-local-app-data',
+        PROGRAMFILES: 'mock-program-files',
+        'PROGRAMFILES(X86)': 'mock-program-files-x86'
+      });
+
+      const executables = findChromeForWin32(includeChromium);
+
+      expect(executables).to.have.lengthOf(12);
+      expect(executables).to.deep.equal([
+        'mock-local-app-data\\Google\\Chrome SxS\\Application\\chrome.exe',
+        'mock-local-app-data\\Google\\Chrome\\Application\\chrome.exe',
+        'mock-local-app-data\\chrome-win32\\chrome.exe',
+        'mock-local-app-data\\Chromium\\Application\\chrome.exe',
+        'mock-program-files\\Google\\Chrome SxS\\Application\\chrome.exe',
+        'mock-program-files\\Google\\Chrome\\Application\\chrome.exe',
+        'mock-program-files\\chrome-win32\\chrome.exe',
+        'mock-program-files\\Chromium\\Application\\chrome.exe',
+        'mock-program-files-x86\\Google\\Chrome SxS\\Application\\chrome.exe',
+        'mock-program-files-x86\\Google\\Chrome\\Application\\chrome.exe',
+        'mock-program-files-x86\\chrome-win32\\chrome.exe',
+        'mock-program-files-x86\\Chromium\\Application\\chrome.exe'
+      ]);
+    });
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const rewire = require("rewire");
+const chromeVersionModule = rewire("../index.js");
+const extractChromeVersionNumer = chromeVersionModule.__get__('extractChromeVersionNumer');
+
+describe('extractChromeVersionNumer', function() {
+
+  describe('Google Chrome 95.0.4638', function() {
+    it('should return "95.0.4638"', function() {
+      const versionString = 'Google Chrome 95.0.4638';
+      const versionNumber = extractChromeVersionNumer(versionString);
+      assert.equal(versionNumber, '95.0.4638');
+    });
+  });
+
+  describe('Google Chrome 96.0.4664.110', function() {
+    it('should return "96.0.4664.110"', function() {
+      const versionString = 'Google Chrome 96.0.4664.110';
+      const versionNumber = extractChromeVersionNumer(versionString);
+      assert.equal(versionNumber, '96.0.4664.110');
+    });
+  });
+
+  describe('Google Chrome 97.0.4692.71', function() {
+    it('should return "97.0.4692.71"', function() {
+      const versionString = 'Google Chrome 97.0.4692.71';
+      const versionNumber = extractChromeVersionNumer(versionString);
+      assert.equal(versionNumber, '97.0.4692.71');
+    });
+  });
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -41,6 +41,22 @@ describe('Chrome Finder', function() {
     });
   });
 
+  describe('extractChromiumVersionNumer from Chromium 90.0.4430.212 Fedora Project', function() {
+    it('should return "90.0.4430.212"', function() {
+      const versionString = 'Chromium 90.0.4430.212 Fedora Project';
+      const versionNumber = extractChromeVersionNumer(versionString);
+      expect(versionNumber).to.equal('90.0.4430.212');
+    });
+  });
+
+  describe('extractChromiumVersionNumer from Chromium 98.0.4753.0', function() {
+    it('should return "98.0.4753.0"', function() {
+      const versionString = 'Chromium 98.0.4753.0';
+      const versionNumber = extractChromeVersionNumer(versionString);
+      expect(versionNumber).to.equal('98.0.4753.0');
+    });
+  });
+
   describe('getChromeVersionFromOsa when includeChromium=false', function() {
     it('should only find Chrome', function() {
       const includeChromium = false;

--- a/test/test.js
+++ b/test/test.js
@@ -84,16 +84,20 @@ describe('Chrome Finder', function() {
 
       const mockVersion = '98.0.4753.0';
 
-      var execSyncCommand;
+      var execSyncCommands = [];
       chromeVersionModule.__set__('execSync', function(command) {
-          execSyncCommand = command;
+          execSyncCommands.push(command);
+          if (execSyncCommands.length == 1) {
+            throw "not found"
+          }
           return Buffer.from(mockVersion);
       });
 
       const version = getChromeVersionFromOsa(includeChromium);
 
-      expect(execSyncCommand).to.not.include('Google Chrome');
-      expect(execSyncCommand).to.include('Chromium');
+      expect(execSyncCommands.length).equal(2);
+      expect(execSyncCommands[0]).to.include('Google Chrome');
+      expect(execSyncCommands[1]).to.include('Chromium');
 
       expect(version).to.equal(mockVersion);
     });


### PR DESCRIPTION
Closes https://github.com/testimio/chrome-version/issues/3
Related to https://github.com/giggio/node-chromedriver/issues/335

This PR adds a flag to enable the module to also look for Chromium. By default the existing behaviour (of only looking for Chrome) is preserved as the `includeChromium` flag defaults to `false.

This PR also adds a suite of Tests to prove the functionality of this module, it has tests for both Chrome and Chromium. In addition I took the liberty of adding a commit to enable GitHub Actions, so that the tests are run and can prevent regressions in future.

A couple small bugs were also fixed along the way. including:
1. Support for finding Chrome on newer versions of macOS where `lsregister` produces a slightly different output format